### PR TITLE
DI using CompositionRoot

### DIFF
--- a/CompositionRoot.xcodeproj/project.pbxproj
+++ b/CompositionRoot.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		36984B861F4C09BE00FA7A03 /* O.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36984B851F4C09BE00FA7A03 /* O.swift */; };
 		36984B881F4C09D000FA7A03 /* P.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36984B871F4C09D000FA7A03 /* P.swift */; };
 		36984B8A1F4C141C00FA7A03 /* D.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36984B891F4C141C00FA7A03 /* D.swift */; };
+		36984B8C1F4C155C00FA7A03 /* ApplicationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36984B8B1F4C155C00FA7A03 /* ApplicationContext.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,6 +78,7 @@
 		36984B851F4C09BE00FA7A03 /* O.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = O.swift; sourceTree = "<group>"; };
 		36984B871F4C09D000FA7A03 /* P.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = P.swift; sourceTree = "<group>"; };
 		36984B891F4C141C00FA7A03 /* D.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = D.swift; sourceTree = "<group>"; };
+		36984B8B1F4C155C00FA7A03 /* ApplicationContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationContext.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +150,7 @@
 				36984B831F4C099E00FA7A03 /* N.swift */,
 				36984B851F4C09BE00FA7A03 /* O.swift */,
 				36984B871F4C09D000FA7A03 /* P.swift */,
+				36984B8B1F4C155C00FA7A03 /* ApplicationContext.swift */,
 			);
 			path = CompositionRoot;
 			sourceTree = "<group>";
@@ -320,6 +323,7 @@
 				36984B841F4C099E00FA7A03 /* N.swift in Sources */,
 				36984B421F4C07C500FA7A03 /* ViewController.swift in Sources */,
 				36984B721F4C086A00FA7A03 /* C.swift in Sources */,
+				36984B8C1F4C155C00FA7A03 /* ApplicationContext.swift in Sources */,
 				36984B401F4C07C500FA7A03 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CompositionRoot.xcodeproj/project.pbxproj
+++ b/CompositionRoot.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		368535F41F4C1AEC00187353 /* DFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368535F31F4C1AEC00187353 /* DFactory.swift */; };
+		368535F61F4C1BC600187353 /* CFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368535F51F4C1BC600187353 /* CFactory.swift */; };
+		368535F81F4C1C5300187353 /* BFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368535F71F4C1C5300187353 /* BFactory.swift */; };
+		368535FA1F4C1C9D00187353 /* AFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368535F91F4C1C9D00187353 /* AFactory.swift */; };
 		36984B401F4C07C500FA7A03 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36984B3F1F4C07C500FA7A03 /* AppDelegate.swift */; };
 		36984B421F4C07C500FA7A03 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36984B411F4C07C500FA7A03 /* ViewController.swift */; };
 		36984B451F4C07C500FA7A03 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 36984B431F4C07C500FA7A03 /* Main.storyboard */; };
@@ -50,6 +54,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		368535F31F4C1AEC00187353 /* DFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DFactory.swift; sourceTree = "<group>"; };
+		368535F51F4C1BC600187353 /* CFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CFactory.swift; sourceTree = "<group>"; };
+		368535F71F4C1C5300187353 /* BFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BFactory.swift; sourceTree = "<group>"; };
+		368535F91F4C1C9D00187353 /* AFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AFactory.swift; sourceTree = "<group>"; };
 		36984B3C1F4C07C500FA7A03 /* CompositionRoot.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CompositionRoot.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		36984B3F1F4C07C500FA7A03 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		36984B411F4C07C500FA7A03 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -106,6 +114,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		368535F21F4C1ADE00187353 /* Factories */ = {
+			isa = PBXGroup;
+			children = (
+				368535F91F4C1C9D00187353 /* AFactory.swift */,
+				368535F71F4C1C5300187353 /* BFactory.swift */,
+				368535F51F4C1BC600187353 /* CFactory.swift */,
+				368535F31F4C1AEC00187353 /* DFactory.swift */,
+			);
+			path = Factories;
+			sourceTree = "<group>";
+		};
 		36984B331F4C07C500FA7A03 = {
 			isa = PBXGroup;
 			children = (
@@ -129,6 +148,7 @@
 		36984B3E1F4C07C500FA7A03 /* CompositionRoot */ = {
 			isa = PBXGroup;
 			children = (
+				368535F21F4C1ADE00187353 /* Factories */,
 				36984B3F1F4C07C500FA7A03 /* AppDelegate.swift */,
 				36984B411F4C07C500FA7A03 /* ViewController.swift */,
 				36984B431F4C07C500FA7A03 /* Main.storyboard */,
@@ -313,17 +333,21 @@
 				36984B741F4C08B700FA7A03 /* F.swift in Sources */,
 				36984B701F4C083400FA7A03 /* B.swift in Sources */,
 				36984B821F4C098C00FA7A03 /* M.swift in Sources */,
+				368535FA1F4C1C9D00187353 /* AFactory.swift in Sources */,
 				36984B781F4C090B00FA7A03 /* H.swift in Sources */,
 				36984B7A1F4C092200FA7A03 /* I.swift in Sources */,
 				36984B6E1F4C07FB00FA7A03 /* A.swift in Sources */,
 				36984B801F4C097300FA7A03 /* L.swift in Sources */,
 				36984B7E1F4C095C00FA7A03 /* K.swift in Sources */,
 				36984B8A1F4C141C00FA7A03 /* D.swift in Sources */,
+				368535F81F4C1C5300187353 /* BFactory.swift in Sources */,
 				36984B761F4C08F200FA7A03 /* G.swift in Sources */,
 				36984B841F4C099E00FA7A03 /* N.swift in Sources */,
 				36984B421F4C07C500FA7A03 /* ViewController.swift in Sources */,
 				36984B721F4C086A00FA7A03 /* C.swift in Sources */,
+				368535F61F4C1BC600187353 /* CFactory.swift in Sources */,
 				36984B8C1F4C155C00FA7A03 /* ApplicationContext.swift in Sources */,
+				368535F41F4C1AEC00187353 /* DFactory.swift in Sources */,
 				36984B401F4C07C500FA7A03 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -569,6 +593,7 @@
 				36984B661F4C07C500FA7A03 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		36984B671F4C07C500FA7A03 /* Build configuration list for PBXNativeTarget "CompositionRootTests" */ = {
 			isa = XCConfigurationList;
@@ -577,6 +602,7 @@
 				36984B691F4C07C500FA7A03 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		36984B6A1F4C07C500FA7A03 /* Build configuration list for PBXNativeTarget "CompositionRootUITests" */ = {
 			isa = XCConfigurationList;
@@ -585,6 +611,7 @@
 				36984B6C1F4C07C500FA7A03 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/CompositionRoot/A.swift
+++ b/CompositionRoot/A.swift
@@ -4,59 +4,15 @@ protocol AProtocol {
 
 class A: AProtocol {
     
-    let f: FProtocol
-    let g: GProtocol
-    let h: HProtocol
-    let i: IProtocol
-    let j: JProtocol
-    let k: KProtocol
-    let l: LProtocol
-    let m: MProtocol
-    let n: NProtocol
-    let o: OProtocol
-    let p: PProtocol
-    
-    init(f: FProtocol,
-         g: GProtocol,
-         h: HProtocol,
-         i: IProtocol,
-         j: JProtocol,
-         k: KProtocol,
-         l: LProtocol,
-         m: MProtocol,
-         n: NProtocol,
-         o: OProtocol,
-         p: PProtocol
-        ) {
-        self.f = f
-        self.g = g
-        self.h = h
-        self.i = i
-        self.j = j
-        self.k = k
-        self.l = l
-        self.m = m
-        self.n = n
-        self.o = o
-        self.p = p
+    let applicationContext: ApplicationContext
+    init(applicationContext: ApplicationContext) {
+        self.applicationContext = applicationContext
     }
     
     func aMethod() {
-        let b = B(f: f,
-                  g: g,
-                  h: h,
-                  i: i,
-                  j: j,
-                  k: k,
-                  l: l,
-                  m: m,
-                  n: n,
-                  o: o,
-                  p: p
-        )
-        
+        let b = B(applicationContext: applicationContext)
         b.bMethod()
-        f.fMethod2()
-        g.gMethod2()
+        applicationContext.f.fMethod2()
+        applicationContext.g.gMethod2()
     }
 }

--- a/CompositionRoot/A.swift
+++ b/CompositionRoot/A.swift
@@ -4,15 +4,20 @@ protocol AProtocol {
 
 class A: AProtocol {
     
-    let applicationContext: ApplicationContext
-    init(applicationContext: ApplicationContext) {
-        self.applicationContext = applicationContext
+    private let f: FProtocol
+    private let g: GProtocol
+    private let bFactory: BFactoryProtocol
+
+    init(f: FProtocol, g: GProtocol, bFactory: BFactoryProtocol) {
+        self.f = f
+        self.g = g
+        self.bFactory = bFactory
     }
     
     func aMethod() {
-        let b = B(applicationContext: applicationContext)
+        let b = bFactory.createB()
         b.bMethod()
-        applicationContext.f.fMethod2()
-        applicationContext.g.gMethod2()
+        f.fMethod2()
+        g.gMethod2()
     }
 }

--- a/CompositionRoot/AppDelegate.swift
+++ b/CompositionRoot/AppDelegate.swift
@@ -15,8 +15,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         //Composition Root
-        let a = A(applicationContext: ApplicationContext())
-        
+        let aFactory = AFactory(applicationContext: ApplicationContext())
+        let a = aFactory.createA()
         a.aMethod()
         return true
     }

--- a/CompositionRoot/AppDelegate.swift
+++ b/CompositionRoot/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         //Composition Root
-        let aFactory = AFactory(applicationContext: ApplicationContext())
+        let aFactory = AFactory()
         let a = aFactory.createA()
         a.aMethod()
         return true

--- a/CompositionRoot/AppDelegate.swift
+++ b/CompositionRoot/AppDelegate.swift
@@ -15,18 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         //Composition Root
-        let a = A(f: F.shared,
-               g: G.shared,
-               h: H.shared,
-               i: I.shared,
-               j: J.shared,
-               k: K.shared,
-               l: L.shared,
-               m: M.shared,
-               n: N.shared,
-               o: O.shared,
-               p: P.shared
-        )
+        let a = A(applicationContext: ApplicationContext())
         
         a.aMethod()
         return true

--- a/CompositionRoot/ApplicationContext.swift
+++ b/CompositionRoot/ApplicationContext.swift
@@ -1,0 +1,54 @@
+
+class ApplicationContext {
+    let f: FProtocol
+    let g: GProtocol
+    let h: HProtocol
+    let i: IProtocol
+    let j: JProtocol
+    let k: KProtocol
+    let l: LProtocol
+    let m: MProtocol
+    let n: NProtocol
+    let o: OProtocol
+    let p: PProtocol
+    
+    init(f: FProtocol,
+         g: GProtocol,
+         h: HProtocol,
+         i: IProtocol,
+         j: JProtocol,
+         k: KProtocol,
+         l: LProtocol,
+         m: MProtocol,
+         n: NProtocol,
+         o: OProtocol,
+         p: PProtocol
+        ) {
+        self.f = f
+        self.g = g
+        self.h = h
+        self.i = i
+        self.j = j
+        self.k = k
+        self.l = l
+        self.m = m
+        self.n = n
+        self.o = o
+        self.p = p
+    }
+    
+    convenience init() {
+        self.init(f: F.shared,
+                  g: G.shared,
+                  h: H.shared,
+                  i: I.shared,
+                  j: J.shared,
+                  k: K.shared,
+                  l: L.shared,
+                  m: M.shared,
+                  n: N.shared,
+                  o: O.shared,
+                  p: P.shared
+        )
+    }
+}

--- a/CompositionRoot/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/CompositionRoot/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },

--- a/CompositionRoot/B.swift
+++ b/CompositionRoot/B.swift
@@ -1,17 +1,17 @@
-protocol BPrototol {
+protocol BProtocol {
     func bMethod()
 }
 
-class B: BPrototol {
+class B: BProtocol {
     
-    let applicationContext: ApplicationContext
+    private let cFactory: CFactoryProtocol
     
-    init(applicationContext: ApplicationContext) {
-        self.applicationContext = applicationContext
+    init(cFactory: CFactoryProtocol) {
+        self.cFactory = cFactory
     }
     
     func bMethod() {
-        let c = C(applicationContext: applicationContext)
+        let c = cFactory.createC()
         c.cMethod()
     }
 }

--- a/CompositionRoot/B.swift
+++ b/CompositionRoot/B.swift
@@ -4,57 +4,14 @@ protocol BPrototol {
 
 class B: BPrototol {
     
-    let f: FProtocol
-    let g: GProtocol
-    let h: HProtocol
-    let i: IProtocol
-    let j: JProtocol
-    let k: KProtocol
-    let l: LProtocol
-    let m: MProtocol
-    let n: NProtocol
-    let o: OProtocol
-    let p: PProtocol
+    let applicationContext: ApplicationContext
     
-    init(f: FProtocol,
-         g: GProtocol,
-         h: HProtocol,
-         i: IProtocol,
-         j: JProtocol,
-         k: KProtocol,
-         l: LProtocol,
-         m: MProtocol,
-         n: NProtocol,
-         o: OProtocol,
-         p: PProtocol
-        ) {
-        self.f = f
-        self.g = g
-        self.h = h
-        self.i = i
-        self.j = j
-        self.k = k
-        self.l = l
-        self.m = m
-        self.n = n
-        self.o = o
-        self.p = p
+    init(applicationContext: ApplicationContext) {
+        self.applicationContext = applicationContext
     }
     
     func bMethod() {
-        let c = C(f: f,
-                  g: g,
-                  h: h,
-                  i: i,
-                  j: j,
-                  k: k,
-                  l: l,
-                  m: m,
-                  n: n,
-                  o: o,
-                  p: p
-        )
-        
+        let c = C(applicationContext: applicationContext)
         c.cMethod()
     }
 }

--- a/CompositionRoot/C.swift
+++ b/CompositionRoot/C.swift
@@ -3,14 +3,14 @@ protocol CProtocol {
 }
 
 class C: CProtocol {
-    let applicationContext: ApplicationContext
-    init(applicationContext: ApplicationContext) {
-        self.applicationContext = applicationContext
+    private let dFactory: DFactoryProtocol
+
+    init(dFactory: DFactoryProtocol) {
+        self.dFactory = dFactory
     }
     
-    
     func cMethod() {
-        let d = D((applicationContext: applicationContext))
+        let d = dFactory.createD()
         d.dMethod()
     }
 }

--- a/CompositionRoot/C.swift
+++ b/CompositionRoot/C.swift
@@ -3,57 +3,14 @@ protocol CProtocol {
 }
 
 class C: CProtocol {
-    let f: FProtocol
-    let g: GProtocol
-    let h: HProtocol
-    let i: IProtocol
-    let j: JProtocol
-    let k: KProtocol
-    let l: LProtocol
-    let m: MProtocol
-    let n: NProtocol
-    let o: OProtocol
-    let p: PProtocol
-    
-    init(f: FProtocol,
-         g: GProtocol,
-         h: HProtocol,
-         i: IProtocol,
-         j: JProtocol,
-         k: KProtocol,
-         l: LProtocol,
-         m: MProtocol,
-         n: NProtocol,
-         o: OProtocol,
-         p: PProtocol
-         ) {
-        self.f = f
-        self.g = g
-        self.h = h
-        self.i = i
-        self.j = j
-        self.k = k
-        self.l = l
-        self.m = m
-        self.n = n
-        self.o = o
-        self.p = p
+    let applicationContext: ApplicationContext
+    init(applicationContext: ApplicationContext) {
+        self.applicationContext = applicationContext
     }
     
+    
     func cMethod() {
-        let d = D(f: f,
-                  g: g,
-                  h: h,
-                  i: i,
-                  j: j,
-                  k: k,
-                  l: l,
-                  m: m,
-                  n: n,
-                  o: o,
-                  p: p
-        )
-        
+        let d = D((applicationContext: applicationContext))
         d.dMethod()
     }
 }

--- a/CompositionRoot/D.swift
+++ b/CompositionRoot/D.swift
@@ -3,52 +3,20 @@ protocol DProtocol {
 }
 
 class D: DProtocol {
-    let f: FProtocol
-    let g: GProtocol
-    let h: HProtocol
-    let i: IProtocol
-    let j: JProtocol
-    let k: KProtocol
-    let l: LProtocol
-    let m: MProtocol
-    let n: NProtocol
-    let o: OProtocol
-    let p: PProtocol
-    
-    init(f: FProtocol,
-         g: GProtocol,
-         h: HProtocol,
-         i: IProtocol,
-         j: JProtocol,
-         k: KProtocol,
-         l: LProtocol,
-         m: MProtocol,
-         n: NProtocol,
-         o: OProtocol,
-         p: PProtocol
-         ) {
-        self.f = f
-        self.g = g
-        self.h = h
-        self.i = i
-        self.j = j
-        self.k = k
-        self.l = l
-        self.m = m
-        self.n = n
-        self.o = o
-        self.p = p
+    let applicationContext: ApplicationContext
+    init(applicationContext: ApplicationContext) {
+        self.applicationContext = applicationContext
     }
     
     func dMethod() {
-        f.fMethod1()
-        g.gMethod1()
-        h.hMethod()
-        i.iMethod()
-        j.jMethod()
-        k.kMethod()
-        l.lMethod()
-        m.mMethod()
-        n.nMethod()
+        applicationContext.f.fMethod1()
+        applicationContext.g.gMethod1()
+        applicationContext.h.hMethod()
+        applicationContext.i.iMethod()
+        applicationContext.j.jMethod()
+        applicationContext.k.kMethod()
+        applicationContext.l.lMethod()
+        applicationContext.m.mMethod()
+        applicationContext.n.nMethod()
     }
 }

--- a/CompositionRoot/D.swift
+++ b/CompositionRoot/D.swift
@@ -3,7 +3,8 @@ protocol DProtocol {
 }
 
 class D: DProtocol {
-    let applicationContext: ApplicationContext
+    private let applicationContext: ApplicationContext
+
     init(applicationContext: ApplicationContext) {
         self.applicationContext = applicationContext
     }

--- a/CompositionRoot/Factories/AFactory.swift
+++ b/CompositionRoot/Factories/AFactory.swift
@@ -1,0 +1,19 @@
+protocol AFactoryProtocol {
+    func createA() -> AProtocol
+}
+
+class AFactory: AFactoryProtocol {
+    private let applicationContext: ApplicationContext
+    
+    init(applicationContext: ApplicationContext) {
+        self.applicationContext = applicationContext
+    }
+    
+    func createA() -> AProtocol {
+        return A(f: applicationContext.f,
+                 g: applicationContext.g,
+                 bFactory: BFactory(applicationContext: applicationContext)
+        )
+    }
+    
+}

--- a/CompositionRoot/Factories/AFactory.swift
+++ b/CompositionRoot/Factories/AFactory.swift
@@ -3,16 +3,12 @@ protocol AFactoryProtocol {
 }
 
 class AFactory: AFactoryProtocol {
-    private let applicationContext: ApplicationContext
-    
-    init(applicationContext: ApplicationContext) {
-        self.applicationContext = applicationContext
-    }
-    
+
     func createA() -> AProtocol {
+        let applicationContext = ApplicationContext()
         return A(f: applicationContext.f,
                  g: applicationContext.g,
-                 bFactory: BFactory(applicationContext: applicationContext)
+                 bFactory: BFactory()
         )
     }
     

--- a/CompositionRoot/Factories/BFactory.swift
+++ b/CompositionRoot/Factories/BFactory.swift
@@ -1,0 +1,16 @@
+protocol BFactoryProtocol {
+    func createB() -> BProtocol
+}
+
+class BFactory: BFactoryProtocol {
+    private let applicationContext: ApplicationContext
+    
+    init(applicationContext: ApplicationContext) {
+        self.applicationContext = applicationContext
+    }
+    
+    func createB() -> BProtocol {
+        return B(cFactory: CFactory(applicationContext: applicationContext))
+    }
+    
+}

--- a/CompositionRoot/Factories/BFactory.swift
+++ b/CompositionRoot/Factories/BFactory.swift
@@ -3,14 +3,9 @@ protocol BFactoryProtocol {
 }
 
 class BFactory: BFactoryProtocol {
-    private let applicationContext: ApplicationContext
-    
-    init(applicationContext: ApplicationContext) {
-        self.applicationContext = applicationContext
-    }
-    
+
     func createB() -> BProtocol {
-        return B(cFactory: CFactory(applicationContext: applicationContext))
+        return B(cFactory: CFactory())
     }
     
 }

--- a/CompositionRoot/Factories/CFactory.swift
+++ b/CompositionRoot/Factories/CFactory.swift
@@ -3,14 +3,7 @@ protocol CFactoryProtocol {
 }
 
 class CFactory: CFactoryProtocol {
-    private let applicationContext: ApplicationContext
-    
-    init(applicationContext: ApplicationContext) {
-        self.applicationContext = applicationContext
-    }
-    
     func createC() -> CProtocol {
-        return C(dFactory: DFactory(applicationContext: applicationContext))
+        return C(dFactory: DFactory())
     }
-    
 }

--- a/CompositionRoot/Factories/CFactory.swift
+++ b/CompositionRoot/Factories/CFactory.swift
@@ -1,0 +1,16 @@
+protocol CFactoryProtocol {
+    func createC() -> CProtocol
+}
+
+class CFactory: CFactoryProtocol {
+    private let applicationContext: ApplicationContext
+    
+    init(applicationContext: ApplicationContext) {
+        self.applicationContext = applicationContext
+    }
+    
+    func createC() -> CProtocol {
+        return C(dFactory: DFactory(applicationContext: applicationContext))
+    }
+    
+}

--- a/CompositionRoot/Factories/DFactory.swift
+++ b/CompositionRoot/Factories/DFactory.swift
@@ -3,14 +3,9 @@ protocol DFactoryProtocol {
 }
 
 class DFactory: DFactoryProtocol {
-    private let applicationContext: ApplicationContext
-    
-    init(applicationContext: ApplicationContext) {
-        self.applicationContext = applicationContext
-    }
-    
+
     func createD() -> DProtocol {
-        return D(applicationContext: applicationContext)
+        return D(applicationContext: ApplicationContext())
     }
 
 }

--- a/CompositionRoot/Factories/DFactory.swift
+++ b/CompositionRoot/Factories/DFactory.swift
@@ -1,0 +1,16 @@
+protocol DFactoryProtocol {
+    func createD() -> DProtocol
+}
+
+class DFactory: DFactoryProtocol {
+    private let applicationContext: ApplicationContext
+    
+    init(applicationContext: ApplicationContext) {
+        self.applicationContext = applicationContext
+    }
+    
+    func createD() -> DProtocol {
+        return D(applicationContext: applicationContext)
+    }
+
+}


### PR DESCRIPTION
<pre>
The following is the object usage graph.  
AppDelegate ->  A -> B -> C - > D -> F
                     G               G
                     H               H
                                     I
                                     J
                                     K
                                     L
                                     M
                                     N

ApplicationContext -> F
                      G
                      H
                      I
                      J
                      K
                      L
                      M
                      N
                      O
                      P
</pre>
1. A uses B, G, H. 
2. B uses C
3. C uses D 
4. D uses F, H, I, J, K, L, M, N.
5. In PR https://sqbu-github.cisco.com/fanglliu/CompositionRoot/pull/2, we use `ApplicationContext`. It require pass `ApplicationContext` from A, through B, C, to D. Even neither B nor C use any property in `ApplicationContext`.  A  just uses 2 of 11 properties in `ApplicationContext`.  A also has to be inject with `ApplicationContext`. 
6. In this PR, `Composition Root` pattern free A,  B, and C from `ApplicationContext`.  We pass `ApplicationContext` from AFactory, through BFactory, CFactory, to D. 
7. It also make B does not depends on concrete class C and make B depend on abstract `CFactoryProctol` protocol. One of the SOLID principles, Dependency Inversion principle, requires both high level class and low level depend on abstract interface, not concrete class. So we should depend on abstract protocol.  `Composition Root` pattern make us follow this principle.
8. Removing dependency on concrete class also makes unit test easier. 